### PR TITLE
allow Temple of Claudii Vidi to display

### DIFF
--- a/content/province/Asia/Shamika_Ghate/8._ephesos_tomb_garden_and_orchard_of_aphrodisios_and_flavia.md
+++ b/content/province/Asia/Shamika_Ghate/8._ephesos_tomb_garden_and_orchard_of_aphrodisios_and_flavia.md
@@ -18,6 +18,7 @@ tags:
 ---
 
 ## Province
+
 [Asia]({{<relref "..">}}) \
 [Asia (Pleiades)](https://pleiades.stoa.org/places/981509)
 
@@ -61,7 +62,7 @@ Tomb Garden and Orchard of Aphrodisios and Flavia
 
 - [stele](http://vocab.getty.edu/page/aat/300007023)
 - [sarcophagi (coffins)](http://vocab.getty.edu/page/aat/300005947)
-- pvmãrin
+- pvmãrin <!-- What is this? -CDC -->
 - pomarium
 - tomb monuments
 

--- a/content/province/germania_inferior/castra_vetera/ger_inf_castra_vetera.md
+++ b/content/province/germania_inferior/castra_vetera/ger_inf_castra_vetera.md
@@ -23,6 +23,7 @@ tags:
 
 [Germania inferior]({{<relref "..">}})
 
+
 ### Province Description
 
 ## Location
@@ -75,6 +76,10 @@ The partially excavated eastern villa was 78.50 m. wide and 109 m. in length. It
 ### Plans
 
 {{< figure src="../images/castra_vetera_plan1_EUR_GI_VetCas_Lh_carroll.jpg" alt="Plan 1. Plan of the western *praetorium* in the double legionary base with its long apsidal garden (G). Adapted from Lehner 1930, fig. 39. (Rights statement)." title="Plan 1. Plan of the western *praetorium* in the double legionary base with its long apsidal garden (G). Adapted from Lehner 1930, fig. 39. (Rights statement)." >}}
+
+
+
+{{<figure src="../images/castra_vetera_plan1_EUR_GI_VetCas_Lh_carroll.jpg" alt="This is a description of the image for people who can't see the image clearly for whatever reason." title="Caption below the image. (RIGHTS STATEMENT)">}}
 
 ### Images
 

--- a/content/province/italia/region_i/rome/temple_claudii_divi.md
+++ b/content/province/italia/region_i/rome/temple_claudii_divi.md
@@ -5,7 +5,7 @@ date: 2021-02-02T10:57:44-07:00
 province_id: ITALIA
 author: Valerie Aymer
 editor: Rhiannon Pare
-draft: true
+draft: false
 ---
 
 # Province
@@ -44,6 +44,7 @@ A sublocation is any area larger than an individual garden, but located within a
 # Garden
 Gardens of the Temple of Divine Claudius (Roma)<!-- List of gardens in province -->
 <!-- May be left blank for now -->
+
 ### Keywords
 
 - [temple](http://vocab.getty.edu/page/aat/300007595)
@@ -51,8 +52,7 @@ Gardens of the Temple of Divine Claudius (Roma)<!-- List of gardens in province 
 - [porticoes](http://vocab.getty.edu/page/aat/300004145)
 - [nymphaea (garden structures)](http://vocab.getty.edu/page/aat/300006809)
 - [aqueducts](http://vocab.getty.edu/page/aat/300006165)
-- [
-- [
+
 
 ### Garden Description
 

--- a/content/province/judaea/ramat_hanadiv/ramat_hanadiv.md
+++ b/content/province/judaea/ramat_hanadiv/ramat_hanadiv.md
@@ -18,11 +18,6 @@ tags:
 
 ## Province
 
-
-
-
-<!-- Hello Chris jkfhdljashkadshjdshds jds dhsjhdfsjhjk    -->
-
 [Judaea]({{<relref "..">}}) \
 [Iudaea (province) (Pleiades)](https://pleiades.stoa.org/places/981527)
 


### PR DESCRIPTION
This page wasn't showing before because the header had `draft: true` which was preventing it from being published.

There are also a couple of changes from the group session earlier today, and I'm going to just include them now rather that trying to figure out how to not include them...

I also added a couple blank `index.md` documents to the folder hierarchy to prevent some errors in Hugo.  (We'll have to ask @christiancasey about that...)